### PR TITLE
[1ST-WEEK-MISSION] 함수로 만드는 Github Issue Page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,34 @@
+import Issue from './components/Issue.js';
+import MyReact from './core/MyReact.js';
+
+
+const App = () => {
+  const issueComponent = Issue();
+
+  const template = () => {
+    console.log('App template');
+    return `
+      <div>
+        ${issueComponent.template()}
+      </div>
+    `
+  };
+
+  const templateDidMount = () => {
+    console.log('App templateDidMount');
+    issueComponent.templateDidMount();
+  };
+
+  const setEvent = () => {
+    console.log('App setEvent');
+    issueComponent.setEvent();
+  };
+
+  return MyReact.createComponent({
+    template,
+    templateDidMount,
+    setEvent,
+  });
+}
+
+export default App;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,21 @@
+const errorHandler = error => {
+  console.error(error);
+};
+
+const successHandler = response => response;
+
+const requestInterceptor = config => {
+  console.log('intercepted config', config);
+  return config;
+}
+
+const client = myAxios.create({
+  // some options
+});
+client.interceptors.response.use(
+  successHandler,
+  errorHandler,
+)
+client.interceptors.request.use(requestInterceptor);
+
+export default client;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,1 @@
+export * from './issue/index.js';

--- a/src/api/issue/index.js
+++ b/src/api/issue/index.js
@@ -1,0 +1,9 @@
+export const getIssueItemList = async () => {
+  try {
+    const resp = await fetch('data-sources/issues.json');
+    return await resp.json();
+  } catch (e) {
+    console.error(e);
+    return []
+  }
+};

--- a/src/api/myAxios.js
+++ b/src/api/myAxios.js
@@ -1,0 +1,4 @@
+const myAxios = () => {
+  const create = () => {};
+  return {create}
+};

--- a/src/components/Issue.js
+++ b/src/components/Issue.js
@@ -1,0 +1,123 @@
+import IssueItem from './IssueItem.js';
+import MyReact from '../core/MyReact.js';
+import {getIssueItemList} from '../api/index.js';
+import {getIssueTpl} from '../tpl.js';
+
+
+const ISSUE_STATUS = {
+  open: 'open',
+  close: 'close',
+}
+
+const Issue = () => {
+  const [issueList, setIssueList] = MyReact.useState([]);
+  const [issueStatus, setIssueStatus] = MyReact.useState(ISSUE_STATUS.open);
+
+  const fetchIssueList = async () => {
+    const data = await getIssueItemList();
+    setIssueList(data);
+  };
+
+  MyReact.useEffect(() => {
+    fetchIssueList();
+  }, []);
+
+  const handleClickIssueOpens = () => {
+    setIssueStatus(ISSUE_STATUS.open);
+  };
+
+  const handleClickIssueClosed = () => {
+    setIssueStatus(ISSUE_STATUS.close);
+  };
+
+  const getIssueStateElem = status => {
+    switch (status) {
+      case ISSUE_STATUS.open:
+        return document.querySelector(`.${status}-count`);
+      case ISSUE_STATUS.close:
+        return document.querySelector(`.${status}-count`);
+    }
+  };
+
+  const getIssueStatusCount = status => (
+    issueList.filter(issue => issue.status === status).length
+  );
+
+  const getIssueStatusText = (count, status) => {
+    switch (status) {
+      case ISSUE_STATUS.open:
+        return `${count} Opens`;
+      case ISSUE_STATUS.close:
+        return `${count} Closed`;
+    }
+  };
+
+  const renderIssueCounts = status => {
+    getIssueStateElem(status).textContent = getIssueStatusText(
+      getIssueStatusCount(status),
+      status,
+    );
+  };
+
+  const renderIssueStatusTabFontBold = status => {
+    if (status !== issueStatus) {
+      return;
+    }
+
+    const fontBoldClassName = 'font-bold';
+    switch (status) {
+      case ISSUE_STATUS.open:
+        getIssueStateElem(ISSUE_STATUS.close).classList.remove(fontBoldClassName);
+        getIssueStateElem(ISSUE_STATUS.open).classList.add(fontBoldClassName);
+        return;
+      case ISSUE_STATUS.close:
+        getIssueStateElem(ISSUE_STATUS.open).classList.remove(fontBoldClassName);
+        getIssueStateElem(ISSUE_STATUS.close).classList.add(fontBoldClassName);
+        return;
+    }
+  };
+
+  const renderIssueStatusTab = () => {
+    Object.values(ISSUE_STATUS).map(status => {
+      renderIssueStatusTabFontBold(status);
+      renderIssueCounts(status);
+    });
+  };
+
+  const renderIssueItems = () => {
+    issueList
+      .filter(issue => issue.status === issueStatus)
+      .map(issueItem => IssueItem({issueItem}))
+      .map(issueItemComponent => {
+        document.querySelector('.issue-list > ul').innerHTML += issueItemComponent.template();
+      });
+  };
+
+  const template = () => {
+    console.log('Issue template');
+    return getIssueTpl();
+  };
+
+  const templateDidMount = () => {
+    console.log('Issue templateDidMount');
+    renderIssueStatusTab();
+    renderIssueItems();
+  };
+
+  const setEvent = () => {
+    console.log('Issue setEvent');
+    getIssueStateElem(ISSUE_STATUS.open)
+      .addEventListener('click', handleClickIssueOpens);
+
+    getIssueStateElem(ISSUE_STATUS.close)
+      .addEventListener('click', handleClickIssueClosed);
+  };
+
+  return MyReact.createComponent({
+    template,
+    templateDidMount,
+    setEvent,
+  });
+}
+
+export default Issue;

--- a/src/components/IssueItem.js
+++ b/src/components/IssueItem.js
@@ -1,0 +1,18 @@
+import MyReact from '../core/MyReact.js';
+import {getIssueItemTpl} from '../tpl.js';
+
+
+const IssueItem = (props) => {
+  const {issueItem} = props;
+
+  const template = () => {
+    console.log('IssueItem template', issueItem);
+    return getIssueItemTpl(issueItem)
+  }
+
+  return MyReact.createComponent({
+    template,
+  });
+}
+
+export default IssueItem;

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -1,0 +1,3 @@
+const Component = props => ({...props});
+
+export default Component;

--- a/src/core/MyReact.js
+++ b/src/core/MyReact.js
@@ -1,0 +1,83 @@
+import Component from './Component.js';
+
+
+const MyReact = (() => {
+  const options = {
+    hooks: [],
+    hookIdx: 0,
+    renderCount: 0,
+    container: null,
+    root: null,
+  }
+
+  const useEffect = (callback, depArr) => {
+    const {
+      hooks,
+      hookIdx,
+    } = options;
+
+    const oldDeps = hooks[hookIdx];
+    let isChanged = true;
+    if (oldDeps) {
+      isChanged = depArr.some(
+        (dep, idx) => !Object.is(dep, oldDeps[idx])
+      );
+    }
+
+    if (isChanged) {
+      callback();
+    }
+    options.hooks[hookIdx] = depArr;
+    options.hookIdx += 1;
+  }
+
+  const useState = (initState) => {
+    const {
+      hooks,
+      hookIdx,
+    } = options;
+
+    const state = hooks[hookIdx] || initState;
+    const setState = (newState) => {
+      hooks[hookIdx] = newState;
+      _render();
+    }
+    options.hookIdx += 1;
+    return [state, setState];
+  }
+
+  const _render = () => {
+    const {container, root} = options;
+    if (!container || !root) {
+      return;
+    }
+    if (options.hookIdx > 100) {
+      console.error('rendering called too much!')
+      return;
+    }
+
+    const {template, templateDidMount, setEvent} = root();
+    container.innerHTML = template();
+    templateDidMount();
+    setEvent();
+
+    options.hookIdx = 0;
+    options.renderCount += 1;
+    console.log('here _render()', options);
+    console.log('==============================');
+  };
+
+  const render = (root, container) => {
+    options.container = container;
+    options.root = root;
+    _render();
+  }
+
+  const createComponent = ({template, templateDidMount, setEvent}) => (
+    Component({template, templateDidMount, setEvent})
+  );
+
+  return {useEffect, useState, render, createComponent};
+})();
+
+export default MyReact;

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,8 @@
+import App from './App.js';
+import MyReact from './core/MyReact.js';
+
+
+MyReact.render(
+  App,
+  document.getElementById('app'),
+)


### PR DESCRIPTION
## 기능 요구 사항
![image](https://user-images.githubusercontent.com/23185933/200170974-e7274d1e-39f3-4093-9c76-a92694d04c45.png)

- 초기 로딩시에 위 화면과 같은 화면을 보여준다.
  - 헤더영역에 opens, closed 갯수를 올바르게 표시
  - 본문영역에 issue 리스트를 표시
- opens , closed 버튼을 선택하면 각각 해당하는 내용을 노출.
- 그외 기능(issue 생성, 검색등)은 구현하지 않으며, 본인이 하고 싶으면 할 수 있다.
- 기능 완성도를 올리기 보다는, 코드 리팩토링에 집중하는 것을 추천.

## 작업 사항
- MyReact prototype 구현
- base Component 구현
- main.js, App.js 초기 구조 구현
- Issue, IssueItem component 구현
- issue api 구현
- myAxios skeleton 추가
